### PR TITLE
Option to add archive to the downstream pipeline steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,15 @@ The name of the archive to be created. Currently only `.tar` is supported (will 
 
 *Default:* `build.tar`
 
+### addToDistFiles
+
+Set `addToDistFiles` to `true` if you would like the archive file to be added
+to the `distFiles` array so that it can be included in downstream
+pipeline steps. (The archive will automatically be copied into the
+`distDir` folder when this is `true`).
+
+*Default:* `false`
+
 ### packedDirName
 
 The name of the directory inside the tarball. By default, `context.distDir` is `deploy-dist` and gets packed up.  
@@ -75,6 +84,7 @@ Override this if you need the unpacked directory to be named something other tha
 The following properties are expected to be present on the deployment `context` object:
 
 - `distDir` (provided by [ember-cli-deploy-build][2])
+- `distFiles` (provided by [ember-cli-deploy-build][2])
 
 ## Running Tests
 

--- a/index.js
+++ b/index.js
@@ -20,14 +20,19 @@ module.exports = {
         distDir: function(context) {
           return context.distDir;
         },
-        packedDirName: false
+        distFiles: function(context) {
+          return context.distFiles;
+        },
+        packedDirName: false,
+        addToDistFiles: false
       },
 
       didBuild: function(context) {
         var self = this;
-        var archivePath = this.readConfig('archivePath');
-        var archiveName = this.readConfig('archiveName');
-        this.distDir    = this.readConfig('distDir');
+        var archivePath    = this.readConfig('archivePath');
+        var archiveName    = this.readConfig('archiveName');
+        var addToDistFiles = this.readConfig('addToDistFiles');
+        this.distDir       = this.readConfig('distDir');
 
         // ensure our `archivePath` directory is avaiable
         fs.mkdirsSync(archivePath);
@@ -40,10 +45,17 @@ module.exports = {
             self._cleanup(context);
           })
           .then(function(){
+            if (addToDistFiles) {
+              var distArchivePath = path.join(self.distDir, archiveName);
+              fs.copySync(path.join(archivePath, archiveName),
+                          path.join(self.distDir, archiveName));
+              var distFiles = self.readConfig('distFiles');
+              distFiles.push(archiveName);
+              self.log('copied tarball to ' + distArchivePath);
+            }
             self.log('tarball ok');
-
             return {
-              archiveDir: archivePath,
+              archiveDir:  archivePath,
               archiveName: archiveName
             };
           })


### PR DESCRIPTION
Loading `distDir` using `this.readConfig()` will allow people to supply the `distDir` as a function as well as a string in the `config/deploy.js` file.

Also I added a config option that allows the archive file to be processed by downstream pipeline steps
