### PR TITLE
Augment the deployment context in the `setup` hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ $ ember deploy
 For detailed information on what plugin hooks are and how they work, please refer to the [Plugin Documentation][1].
 
 - `configure`
+- `setup`
 - `didBuild`
 
 ## Configuration Options
@@ -69,6 +70,12 @@ The name of the directory inside the tarball. By default, `context.distDir` is `
 Override this if you need the unpacked directory to be named something other than `deploy-dist`.
 
 *Default:* `false`
+
+## Deployment Context
+
+`archivePath` and `archiveName` are added to the deployment context for use by other plugins. 
+Note that this is done in the `setup` hook, not in `didBuild` (where most of the action happens).
+This is to ensure the properties are available to hooks that run during `deploy:activate` and `deploy:list` commands.
 
 ## Prerequisites
 

--- a/index.js
+++ b/index.js
@@ -23,10 +23,18 @@ module.exports = {
         packedDirName: false
       },
 
+      setup: function(/* context */) {
+        this.log('setting `archivePath` and `archiveName` in deployment context', { verbose: true });
+
+        return {
+          archivePath: this.readConfig('archivePath'),
+          archiveName: this.readConfig('archiveName')
+        };
+      },
+
       didBuild: function(context) {
         var self = this;
         var archivePath = this.readConfig('archivePath');
-        var archiveName = this.readConfig('archiveName');
         this.distDir    = this.readConfig('distDir');
 
         // ensure our `archivePath` directory is avaiable
@@ -41,11 +49,6 @@ module.exports = {
           })
           .then(function(){
             self.log('tarball ok');
-
-            return {
-              archivePath: archivePath,
-              archiveName: archiveName
-            };
           })
           .catch(function(err){
             throw new Error(err.stack);


### PR DESCRIPTION
This ensures `archivePath` and `archiveName` are available to other plugins
during `deploy:activate` and `deploy:list` commands.
