### PR TITLE
Replace deprecated tar.gz with tar package

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@ var RSVP       = require('rsvp');
 var fs         = require('fs-extra');
 var path       = require('path');
 var move       = RSVP.denodeify(fs.move);
-var targz      = require('tar.gz');
+var tar      = require('tar');
 
 module.exports = {
   name: 'ember-cli-deploy-archive',
@@ -59,11 +59,18 @@ module.exports = {
       _pack: function(dir) {
         var archivePath = this.readConfig('archivePath');
         var archiveName = this.readConfig('archiveName');
+        var containingDirectory = path.dirname(dir);
+        var target = path.basename(dir);
+
         var fileName = path.join(archivePath, archiveName);
 
         this.log('saving tarball of ' + dir + ' to ' + fileName);
 
-        return targz().compress(dir, fileName);
+        return tar.c({
+          gzip: true,
+          file: fileName,
+          C: containingDirectory
+        }, [target]);
       },
 
       // to allow configurable naming of the directory inside the tarball

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "ember-cli-deploy-plugin": "^0.2.9",
     "fs-extra": "^0.26.5",
     "rsvp": "^3.5.0",
-    "tar.gz": "^1.0.5"
+    "tar": "^4.0.2"
   },
   "devDependencies": {
     "chai": "^3.3.0",

--- a/tests/index-test.js
+++ b/tests/index-test.js
@@ -10,7 +10,7 @@ var RSVP = require('rsvp');
 var fs = require('fs');
 var stat = RSVP.denodeify(fs.stat);
 var path = require('path');
-var targz = require('tar.gz');
+var tar = require('tar');
 
 var ARCHIVE_NAME = 'build.tar';
 var ARCHIVE_PATH = process.cwd() + '/tmp/deploy-archive';
@@ -111,7 +111,10 @@ describe('archive plugin', function() {
               assert.ok(stats.isFile());
             })
             .then(function() {
-              return targz().extract(fileName, archivePath);
+              return tar.x({
+                file: fileName,
+                C: archivePath
+              });
             })
             .then(function() {
               var extractedDir = archivePath + '/' + DIST_DIR;

--- a/yarn.lock
+++ b/yarn.lock
@@ -846,10 +846,6 @@ block-stream@*:
   dependencies:
     inherits "~2.0.0"
 
-bluebird@^2.9.34:
-  version "2.11.0"
-  resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-2.11.0.tgz#534b9033c022c9579c56ba3b3e5a5caafbb650e1"
-
 bluebird@^3.1.1, bluebird@^3.4.6:
   version "3.5.0"
   resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.5.0.tgz#791420d7f551eea2897453a8a77653f96606d67c"
@@ -1443,7 +1439,7 @@ commander@2.8.x:
   dependencies:
     graceful-readlink ">= 1.0.0"
 
-commander@^2.6.0, commander@^2.8.1, commander@^2.9.0:
+commander@^2.6.0, commander@^2.9.0:
   version "2.9.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.9.0.tgz#9c99094176e12240cb22d6c5146098400fe0f7d4"
   dependencies:
@@ -2637,7 +2633,7 @@ fstream-npm@~1.0.7:
     fstream-ignore "^1.0.0"
     inherits "2"
 
-fstream@^1.0.0, fstream@^1.0.2, fstream@^1.0.8, fstream@~1.0.8:
+fstream@^1.0.0, fstream@^1.0.2, fstream@~1.0.8:
   version "1.0.11"
   resolved "https://registry.yarnpkg.com/fstream/-/fstream-1.0.11.tgz#5c1fb1f117477114f0632a0eb4b71b3cb0fd3171"
   dependencies:
@@ -3854,6 +3850,18 @@ minimist@^1.1.1:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.0.tgz#a35008b20f41383eec1fb914f4cd5df79a264284"
 
+minipass@^2.2.1:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/minipass/-/minipass-2.2.1.tgz#5ada97538b1027b4cf7213432428578cb564011f"
+  dependencies:
+    yallist "^3.0.0"
+
+minizlib@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/minizlib/-/minizlib-1.0.4.tgz#8ebb51dd8bbe40b0126b5633dbb36b284a2f523c"
+  dependencies:
+    minipass "^2.2.1"
+
 mkdirp@0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.3.0.tgz#1bbf5ab1ba827af23575143490426455f481fe1e"
@@ -3902,10 +3910,6 @@ morgan@^1.8.1:
     depd "~1.1.0"
     on-finished "~2.3.0"
     on-headers "~1.0.1"
-
-mout@^0.11.0:
-  version "0.11.1"
-  resolved "https://registry.yarnpkg.com/mout/-/mout-0.11.1.tgz#ba3611df5f0e5b1ffbfd01166b8f02d1f5fa2b99"
 
 mout@^1.0.0:
   version "1.0.0"
@@ -5212,23 +5216,23 @@ tap-parser@^5.1.0:
   optionalDependencies:
     readable-stream "^2"
 
-tar.gz@^1.0.5:
-  version "1.0.5"
-  resolved "https://registry.yarnpkg.com/tar.gz/-/tar.gz-1.0.5.tgz#e1ada7e45ef2241b4b1ee58123c8f40b5d3c1bc4"
-  dependencies:
-    bluebird "^2.9.34"
-    commander "^2.8.1"
-    fstream "^1.0.8"
-    mout "^0.11.0"
-    tar "^2.1.1"
-
-tar@^2.0.0, tar@^2.1.1, tar@~2.2.1:
+tar@^2.0.0, tar@~2.2.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/tar/-/tar-2.2.1.tgz#8e4d2a256c0e2185c6b18ad694aec968b83cb1d1"
   dependencies:
     block-stream "*"
     fstream "^1.0.2"
     inherits "2"
+
+tar@^4.0.2:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/tar/-/tar-4.0.2.tgz#e8e22bf3eec330e5c616d415a698395e294e8fad"
+  dependencies:
+    chownr "^1.0.1"
+    minipass "^2.2.1"
+    minizlib "^1.0.4"
+    mkdirp "^0.5.0"
+    yallist "^3.0.2"
 
 temp@0.8.3:
   version "0.8.3"
@@ -5657,6 +5661,10 @@ xtend@^4.0.0, xtend@~4.0.0:
 yallist@^2.0.0:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-2.1.2.tgz#1c11f9218f076089a47dd512f93c6699a6a81d52"
+
+yallist@^3.0.0, yallist@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/yallist/-/yallist-3.0.2.tgz#8452b4bb7e83c7c188d8041c1a837c773d6d8bb9"
 
 yam@0.0.22:
   version "0.0.22"


### PR DESCRIPTION
Slightly different API, but seems to be essentially the same tool.