### PR TITLE
Run in the willUpload hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ For detailed information on what plugin hooks are and how they work, please refe
 
 - `configure`
 - `setup`
-- `didBuild`
+- `willUpload`
 
 ## Configuration Options
 
@@ -74,7 +74,7 @@ Override this if you need the unpacked directory to be named something other tha
 ## Deployment Context
 
 `archivePath` and `archiveName` are added to the deployment context for use by other plugins. 
-Note that this is done in the `setup` hook, not in `didBuild` (where most of the action happens).
+Note that this is done in the `setup` hook, not in `willUpload` (where most of the action happens).
 This is to ensure the properties are available to hooks that run during `deploy:activate` and `deploy:list` commands.
 
 ## Prerequisites

--- a/index.js
+++ b/index.js
@@ -32,7 +32,7 @@ module.exports = {
         };
       },
 
-      didBuild: function(context) {
+      willUpload: function(context) {
         var self = this;
         var archivePath = this.readConfig('archivePath');
         this.distDir    = this.readConfig('distDir');

--- a/tests/index-test.js
+++ b/tests/index-test.js
@@ -63,7 +63,7 @@ describe('archive plugin', function() {
     it('implements the correct hooks', function() {
       assert.equal(typeof plugin.configure, 'function');
       assert.equal(typeof plugin.setup, 'function');
-      assert.equal(typeof plugin.didBuild, 'function');
+      assert.equal(typeof plugin.willUpload, 'function');
     });
 
     describe('configure hook', function() {
@@ -96,14 +96,14 @@ describe('archive plugin', function() {
       });
     });
 
-    describe('didBuild hook', function() {
+    describe('willUpload hook', function() {
 
       it('creates a tarball of the dist folder', function() {
         this.timeout(10000);
         var archivePath = context.config.archive.archivePath;
         var archiveName = context.config.archive.archiveName;
 
-        return assert.isFulfilled(plugin.didBuild(context))
+        return assert.isFulfilled(plugin.willUpload(context))
           .then(function() {
             var fileName = path.join(archivePath, archiveName);
 


### PR DESCRIPTION
While didBuild seems like the correct place for this process it doesn't
jive with other ecd plugins which compress assets in the willUpload
hook.

There is some confusion about where a plugin like this should run.  See https://github.com/ember-cli-deploy/ember-cli-deploy-gzip/pull/28.

Since 1.0 has not been released yet maybe this change can be made here?